### PR TITLE
Accueil: disposition 2 colonnes

### DIFF
--- a/.github/workflows/build-deploy-static.yml
+++ b/.github/workflows/build-deploy-static.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: npm install
+      - name: Build website
+        run: npm run build
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -17,13 +17,13 @@ const FeatureList = [
 
 function Feature({Svg, title, description}) {
   return (
-    <div className={clsx('col col--12')}>
-      <div className={clsx('col col--6')}>
-        <Svg className={styles.featureSvg} role="img" />
-      </div>
+    <div className={clsx('row')}>
       <div className={clsx('col col--6')}>
         <h3>{title}</h3>
         <p>{description}</p>
+      </div>
+      <div className={clsx('col col--6')}>
+        <Svg className={styles.featureSvg} role="img" />
       </div>
     </div>
   );
@@ -33,11 +33,9 @@ export default function HomepageFeatures() {
   return (
     <section className={styles.features}>
       <div className="container">
-        <div className="row">
-          {FeatureList.map((props, idx) => (
-            <Feature key={idx} {...props} />
-          ))}
-        </div>
+        {FeatureList.map((props, idx) => (
+          <Feature key={idx} {...props} />
+        ))}
       </div>
     </section>
   );

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -6,6 +6,22 @@
 }
 
 .featureSvg {
-  height: 400px;
-  width: 600px;
+  max-width: 100%;
+  height: auto;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1.5rem;
+}
+
+@media (min-width: 48rem) {
+  .col--2 {
+    grid-column: span 2;
+  }
+
+  .col--6 {
+    grid-column: span 6;
+  }
 }

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -10,18 +10,57 @@
   height: auto;
 }
 
+/* Implémentation de la grille avec la propriété `dispaly: grid`*/
 .row {
   display: grid;
+  align-items: start;
+  justify-content: start;
   grid-template-columns: repeat(12, 1fr);
   gap: 1.5rem;
 }
 
+/* Les colonnes sont pleine largeur jusqu’à une largeur "tablette" (48rem => 768px) */
 @media (min-width: 48rem) {
+  .col--1 {
+    grid-column: span 1;
+  }
   .col--2 {
     grid-column: span 2;
   }
 
+  .col--3 {
+    grid-column: span 3;
+  }
+
+  .col--4 {
+    grid-column: span 4;
+  }
+
   .col--6 {
     grid-column: span 6;
+  }
+
+  .col--7 {
+    grid-column: span 7;
+  }
+
+  .col--8 {
+    grid-column: span 8;
+  }
+
+  .col--9 {
+    grid-column: span 9;
+  }
+
+  .col--10 {
+    grid-column: span 10;
+  }
+
+  .col--11 {
+    grid-column: span 11;
+  }
+
+  .col--12 {
+    grid-column: span 12;
   }
 }


### PR DESCRIPTION
* Implémentation des classes CSS mortes (ex. `.col--6`), qui ne faisaient rien

* Implémentation d’une grille CSS sommaire (mais uniquement pour l’accueil – pourrait être généralisé)

* `.gitignore`: ignorer fichiers éditeur